### PR TITLE
fix: cast version to correct offset string

### DIFF
--- a/src/BuildingRegistry.Projections.Wms/Migrations/20191213133643_AddWmsViews.cs
+++ b/src/BuildingRegistry.Projections.Wms/Migrations/20191213133643_AddWmsViews.cs
@@ -91,7 +91,7 @@ namespace BuildingRegistry.Projections.Wms.Migrations
                 SELECT
                     [PersistentLocalId] AS [ObjectId],
                     [Id],
-                    CAST([Version] AS nvarchar) AS [VersieId],
+                    CAST([Version] AT TIME ZONE 'Central European Standard Time' AS nvarchar(max)) AS [VersieId],
                     [CalculatedGeometry] AS [Geometry],
                     [GeometryMethod] AS [GeometrieMethode],
                     [Status]
@@ -145,7 +145,7 @@ namespace BuildingRegistry.Projections.Wms.Migrations
                 SELECT
                     [Id],
                     [BuildingUnitPersistentLocalId] AS [ObjectId],
-                    CAST([Version] AS nvarchar) AS [VersieId],
+                    CAST([Version] AT TIME ZONE 'Central European Standard Time' AS nvarchar(max)) AS [VersieId],
                     [PositionMethod] AS [PositieGeometrieMethode],
                     [Status] AS [GebouweenheidStatus],
                     [Function] AS [Functie],


### PR DESCRIPTION
version:
- no longer cuts off the time offset
- gives the correct CET offset

Altered migration -> drop wms schema
```
DROP VIEW [wms].[GebouweenheidNietGerealiseerd]
DROP VIEW [wms].[GebouweenheidGerealiseerd]
DROP VIEW [wms].[GebouweenheidGepland]
DROP VIEW [wms].[GebouweenheidGehistoreerd]
GO
DROP VIEW [wms].[GebouweenheidView]
GO

DROP VIEW [wms].[GebouwGehistoreerd]
DROP VIEW [wms].[GebouwGerealiseerd]
DROP VIEW [wms].[GebouwGepland]
DROP VIEW [wms].[GebouwNietGerealiseerd]
DROP VIEW [wms].[GebouwInAanbouw]
GO
DROP VIEW [wms].[GebouwView]
GO

DROP TABLE [wms].[__EFMigrationsHistoryWmsBuilding]
DROP TABLE [wms].[ProjectionStates]
DROP TABLE [wms].[BuildingUnit_BuildingPersistentLocalIds]
DROP TABLE [wms].[BuildingUnits]
DROP TABLE [wms].[Buildings]
GO
```