### PR TITLE
fix: remove unique index from buildingunit

### DIFF
--- a/src/BuildingRegistry.Projections.Legacy/BuildingUnitDetail/BuildingUnitDetail.cs
+++ b/src/BuildingRegistry.Projections.Legacy/BuildingUnitDetail/BuildingUnitDetail.cs
@@ -100,7 +100,6 @@ namespace BuildingRegistry.Projections.Legacy.BuildingUnitDetail
 
             b.HasIndex(p => p.BuildingId);
             b.HasIndex(p => p.PersistentLocalId)
-                .IsUnique()
                 .IsClustered();
 
             b.HasIndex(p => p.BuildingPersistentLocalId);

--- a/src/BuildingRegistry.Projections.Legacy/Migrations/20200303120306_RemoveUniqueBuildingUnit.Designer.cs
+++ b/src/BuildingRegistry.Projections.Legacy/Migrations/20200303120306_RemoveUniqueBuildingUnit.Designer.cs
@@ -4,14 +4,16 @@ using BuildingRegistry.Projections.Legacy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace BuildingRegistry.Projections.Legacy.Migrations
 {
     [DbContext(typeof(LegacyContext))]
-    partial class LegacyContextModelSnapshot : ModelSnapshot
+    [Migration("20200303120306_RemoveUniqueBuildingUnit")]
+    partial class RemoveUniqueBuildingUnit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BuildingRegistry.Projections.Legacy/Migrations/20200303120306_RemoveUniqueBuildingUnit.cs
+++ b/src/BuildingRegistry.Projections.Legacy/Migrations/20200303120306_RemoveUniqueBuildingUnit.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BuildingRegistry.Projections.Legacy.Migrations
+{
+    public partial class RemoveUniqueBuildingUnit : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_BuildingUnitDetails_PersistentLocalId",
+                schema: "BuildingRegistryLegacy",
+                table: "BuildingUnitDetails");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildingUnitDetails_PersistentLocalId",
+                schema: "BuildingRegistryLegacy",
+                table: "BuildingUnitDetails",
+                column: "PersistentLocalId")
+                .Annotation("SqlServer:Clustered", true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_BuildingUnitDetails_PersistentLocalId",
+                schema: "BuildingRegistryLegacy",
+                table: "BuildingUnitDetails");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildingUnitDetails_PersistentLocalId",
+                schema: "BuildingRegistryLegacy",
+                table: "BuildingUnitDetails",
+                column: "PersistentLocalId",
+                unique: true)
+                .Annotation("SqlServer:Clustered", true);
+        }
+    }
+}


### PR DESCRIPTION
projections can have multiple `null` persistentlocalid's for buildingunit