### PR TITLE
fix: use event name instead of type for sync xml serialization

### DIFF
--- a/src/BuildingRegistry.Projections.Legacy/BuildingSyndication/BuildingSyndicationExtensions.cs
+++ b/src/BuildingRegistry.Projections.Legacy/BuildingSyndication/BuildingSyndicationExtensions.cs
@@ -59,7 +59,7 @@ namespace BuildingRegistry.Projections.Legacy.BuildingSyndication
             if (message.Message is IHasProvenance provenanceMessage)
                 newBuildingSyndicationItem.ApplyProvenance(provenanceMessage.Provenance);
 
-            newBuildingSyndicationItem.SetEventData(message.Message);
+            newBuildingSyndicationItem.SetEventData(message.Message, message.EventName);
 
             await context
                 .BuildingSyndication
@@ -96,8 +96,8 @@ namespace BuildingRegistry.Projections.Legacy.BuildingSyndication
             item.Reason = provenance.Reason;
         }
 
-        public static void SetEventData<T>(this BuildingSyndicationItem syndicationItem, T message)
-            => syndicationItem.EventDataAsXml = message.ToXml(message.GetType().Name).ToString(SaveOptions.DisableFormatting);
+        public static void SetEventData<T>(this BuildingSyndicationItem syndicationItem, T message, string eventName)
+            => syndicationItem.EventDataAsXml = message.ToXml(eventName).ToString(SaveOptions.DisableFormatting);
 
         private static ProjectionItemNotFoundException<BuildingSyndicationProjections> DatabaseItemNotFound(Guid addressId)
             => new ProjectionItemNotFoundException<BuildingSyndicationProjections>(addressId.ToString("D"));

--- a/src/BuildingRegistry.Projections.Legacy/BuildingSyndication/BuildingSyndicationProjections.cs
+++ b/src/BuildingRegistry.Projections.Legacy/BuildingSyndication/BuildingSyndicationProjections.cs
@@ -31,7 +31,7 @@ namespace BuildingRegistry.Projections.Legacy.BuildingSyndication
                 };
 
                 newBuildingSyndicationItem.ApplyProvenance(message.Message.Provenance);
-                newBuildingSyndicationItem.SetEventData(message.Message);
+                newBuildingSyndicationItem.SetEventData(message.Message, message.EventName);
 
                 await context
                     .BuildingSyndication


### PR DESCRIPTION
rebuild or sql replace needed

```
BuildingPersistentLocalIdWasAssigned => BuildingPersistentLocalIdentifierWasAssigned
BuildingUnitPersistentLocalIdWasAssigned => BuildingUnitPersistentLocalIdentifierWasAssigned
BuildingUnitPersistentLocalIdWasDuplicated => BuildingUnitPersistentLocalIdentifierWasDuplicated
BuildingUnitPersistentLocalIdWasRemoved => BuildingUnitPersistentLocalIdentifierWasRemoved
```